### PR TITLE
Add root endpoint and test for coverage (2025-07-15)

### DIFF
--- a/src/main/java/com/movieapi/controller/RootController.java
+++ b/src/main/java/com/movieapi/controller/RootController.java
@@ -1,0 +1,13 @@
+package com.movieapi.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+
+@RestController
+public class RootController {
+    @GetMapping("/")
+    public ResponseEntity<String> root() {
+        return ResponseEntity.ok("Movie Management API is running. See /swagger-ui.html for docs.");
+    }
+}

--- a/src/test/java/com/movieapi/controller/RootControllerTest.java
+++ b/src/test/java/com/movieapi/controller/RootControllerTest.java
@@ -1,0 +1,22 @@
+package com.movieapi.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@WebMvcTest(RootController.class)
+class RootControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void rootEndpoint_ReturnsApiInfo() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Movie Management API is running. See /swagger-ui.html for docs."));
+    }
+}


### PR DESCRIPTION
- Add RootController to handle GET / and return API info message
- Add RootControllerTest to ensure coverage for the root endpoint
- Ensures 75%+ coverage per file
- Resolves 500 error for / and improves API usability
